### PR TITLE
add share buttons to external iframe map page

### DIFF
--- a/external_pages/main_iframe.css
+++ b/external_pages/main_iframe.css
@@ -17,10 +17,21 @@ i {
 }
 
 .banner {
+	height: 50px;
+	flex-shrink: 0;
 	display: flex;
-	padding: 1rem 10px;
+	align-items: center;
+	padding: 0 10px;
 	background: #4d4d4d;
 	color: white;
 	font-family: Helvetica,Arial,sans-serif;
 	justify-content: space-between;
+}
+.btn.banner__button {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	height: 1.75rem;
+	padding: 0 0.375rem;
+	border-color: transparent;
 }

--- a/external_pages/main_iframe.css
+++ b/external_pages/main_iframe.css
@@ -27,6 +27,9 @@ i {
 	font-family: Helvetica,Arial,sans-serif;
 	justify-content: space-between;
 }
+.row.banner__actions {
+	flex-wrap: nowrap;
+}
 .btn.banner__button {
 	display: flex;
 	align-items: center;

--- a/external_pages/main_iframe.html
+++ b/external_pages/main_iframe.html
@@ -5,23 +5,78 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>A Map of Progress Eliminating Costly Parking Mandates</title>
+    <meta name="title" property="og:title" content="A Map of Progress Eliminating Costly Parking Mandates">
     <meta name="description" content="A map of cities which have policies reducing or eliminating costly parking mandates.">
     <meta name="author" content="Parking Reform Network">
+    <meta property="og:url" content="https://parkingreform.org/mandates-map"/>
+    <meta property="og:image" content="//media.example.com/ 1234567.jpg"/>
     <link type="text/css" rel="stylesheet" href="./main_iframe.css">
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU" crossorigin="anonymous">
     <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous"/>
   </head>
   <body>
-  <div id="content">
-  <div class="banner">
-    <span style="margin: 0; font-weight: bold; font-size:1em">Progress on Costly Car Parking Mandates</span>
-    <div class="right">
-      <a href="https://parkingreform.org/mandates-map" target="_blank">
-        <i class="expand-icon fas fa-external-link-alt fa-inverse" title="View fullscreen"></i>
-      </a>
-    </div>
-  </div>
+    <div id="content">
+      <div class="banner">
+        <span style="margin: 0; font-weight: bold; font-size:1em">Progress on Costly Car Parking Mandates</span>
+        <div class="right row gx-2 align-items-center">
+          <div class="col dropdown">
+            <button class="btn btn-outline-light dropdown-toggle banner__button" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="fas fa-share-alt" title="See sharing options"></i>
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+              <li>
+                <a class="dropdown-item" href="https://twitter.com/intent/tweet?text=Costly%20parking%20mandates%20make%20it%20harder%20to%20build%20homes%20and%20fight%20climate%20change!%20Lots%20of%20cities%20are%20reforming%20their%20rules.%20Find%20out%20who!%0A%0Ahttps://parkingreform.org/resources/mandates-map/" target="_blank">
+                  Twitter
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="https://www.facebook.com/sharer/sharer.php?u=https://parkingreform.org/resources/mandates-map/" target="_blank">
+                  Facebook
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fparkingreform.org%2Fresources%2Fmandates-map%2F" target="_blank">
+                  LinkedIn
+                </a>
+              </li>
+              <li>
+                <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#embedModal">
+                  Embed
+                </button>
+              </li>
+            </ul>
+          </div>
+          <a class="btn btn-outline-light banner__button col" href="https://parkingreform.org/mandates-map" target="_blank">
+            <i class="expand-icon fas fa-external-link-alt" title="View fullscreen"></i>
+          </a>
+        </div>
+      </div>
       <iframe id="prn-minimums-iframe" width="100%" height="100%" frameborder="0" src="https://parkingreform.shinyapps.io/parkingmap/"></iframe>
-  </div>
-  <script src="./main_iframe.js"></script>
+    </div>
+    <!-- Embed Modal -->
+    <div class="modal fade" id="embedModal" tabindex="-1" aria-labelledby="embedModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="embedModalLabel">Embed on your website</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <textarea class="col form-control" rows="5" readonly><iframe
+  src="https://parkingreform.org/mandates-map/"
+  width="100%"
+  height="600"
+></iframe></textarea>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="./main_iframe.js"></script>
+    <!-- Bootstrap Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/external_pages/main_iframe.html
+++ b/external_pages/main_iframe.html
@@ -19,7 +19,7 @@
     <div id="content">
       <div class="banner">
         <span style="margin: 0; font-weight: bold; font-size:1em">Progress on Costly Car Parking Mandates</span>
-        <div class="right row gx-2 align-items-center">
+        <div class="right row gx-2 banner__actions align-items-center">
           <div class="col dropdown">
             <button class="btn btn-outline-light dropdown-toggle banner__button" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
               <i class="fas fa-share-alt" title="See sharing options"></i>
@@ -63,7 +63,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-            <textarea class="col form-control" rows="5" readonly><iframe
+            <textarea class="col form-control" rows="6" readonly><iframe
   src="https://parkingreform.org/mandates-map/"
   width="100%"
   height="600"


### PR DESCRIPTION
### Added share dropdown:
![image](https://user-images.githubusercontent.com/379022/142777132-5697ab80-76be-47c5-81f6-3612084af186.png)

### Focus states
![image](https://user-images.githubusercontent.com/379022/142777140-774c9634-fb3d-4942-b587-a5746a8d7a94.png)
![image](https://user-images.githubusercontent.com/379022/142777148-c55f3b2c-e560-4ae3-93b2-d284147574a3.png)

### Active states
![image](https://user-images.githubusercontent.com/379022/142777274-2dabe0e9-af00-4a19-94f8-35d45a2c1c32.png)
![image](https://user-images.githubusercontent.com/379022/142777154-c149f5a7-e8dc-4fde-b185-5761807319f0.png)

### Twitter
![image](https://user-images.githubusercontent.com/379022/142777205-279386d4-e603-44ce-bde7-65db0341081d.png)
### Facebook
- as far as I know, we're unable to pre-populate text, unfortunately

![image](https://user-images.githubusercontent.com/379022/142777249-d210682e-f982-4318-a2c2-41e7db3636c2.png)
### LinkedIn
- I don't think we can link directly to sharing in a post. Instead, we land at this screen:

![image](https://user-images.githubusercontent.com/379022/142777348-35b6dbde-5980-44ff-b7ce-92c1ea47ab9f.png)
### Embed modal
![image](https://user-images.githubusercontent.com/379022/142777373-69dc782f-57a4-42f1-b31c-2dfb0af6ed94.png)
